### PR TITLE
Visual Micro *.vsarduino.h  define breaks intellisense 

### DIFF
--- a/package_elektor_boards_index.json
+++ b/package_elektor_boards_index.json
@@ -43,10 +43,10 @@
         },
         {
           "name": "Elektor AVR-PB boards",
-          "architecture": "avr-pb",
+          "architecture": "avr_pb",
           "version": "1.0.0",
           "category": "Contributed",
-          "url": "https://raw.githubusercontent.com/ElektorLabs/arduino/master/elektor-boards-avr-pb-1.0.0.zip",
+          "url": "https://raw.githubusercontent.com/firmware32/arduino/master/elektor-boards-avr-pb-1.0.0.zip",
           "archiveFileName": "elektor-boards-avr-pb-1.0.0.zip",
           "checksum": "SHA-256:a675123b17ea29fecf3e7af032b0da482c9fcad645be4aadf2366e782d53ba67",
           "size": "166729",

--- a/package_elektor_boards_index.json
+++ b/package_elektor_boards_index.json
@@ -46,7 +46,7 @@
           "architecture": "avr_pb",
           "version": "1.0.0",
           "category": "Contributed",
-          "url": "https://raw.githubusercontent.com/firmware32/arduino/master/elektor-boards-avr-pb-1.0.0.zip",
+          "url": "https://raw.githubusercontent.com/ElektorLabs/arduino/master/elektor-boards-avr-pb-1.0.0.zip",
           "archiveFileName": "elektor-boards-avr-pb-1.0.0.zip",
           "checksum": "SHA-256:a675123b17ea29fecf3e7af032b0da482c9fcad645be4aadf2366e782d53ba67",
           "size": "166729",


### PR DESCRIPTION
   "architecture": "avr-pb" causes a invalid macro error in Visual Studio when using visual micro. I was able to get the error to go away by changing it to "avr_pb" then pulling from my repository fixed the issue. 

So visual micro generates a *.vsarduino.h file one of the defines pulls from the config

bad macro ( doesn't like the "-")
# define ARDUINO_ARCH_AVR-PB

//works fine 
# define ARDUINO_ARCH_AVR_PB

BTW Thanks this is awesome!!!
